### PR TITLE
await the eval so async ops can be passed to tasks.EvaluateExpression

### DIFF
--- a/packages/@aws-cdk/aws-stepfunctions-tasks/lib/eval-nodejs-handler/index.ts
+++ b/packages/@aws-cdk/aws-stepfunctions-tasks/lib/eval-nodejs-handler/index.ts
@@ -15,5 +15,5 @@ export async function handler(event: Event): Promise<any> {
     );
   console.log(`Expression: ${expression}`);
 
-  return eval(expression);
+  return await eval(expression);
 }


### PR DESCRIPTION
Currently the way `EvaluateExpression` is set up, if you pass an async expression to it, it never waits for the execution to complete. By adding an `await` before the `eval()` call, async ops can be passed in. This also works for sync ops same as before (await works with sync code as well).

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
